### PR TITLE
chore: add mdx style comment matches

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.js text eol=lf
+bin/* text eol=lf

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snipsync",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "Sync docs with github repo code snippets",
   "main": "index.js",
   "repository": "git@github.com:temporalio/snipsync.git",

--- a/src/common.js
+++ b/src/common.js
@@ -6,7 +6,8 @@ module.exports = {
   fmtStartCodeBlock: (ext) => '```' + ext,
   readStart: '@@@SNIPSTART',
   readEnd: '@@@SNIPEND',
-  writeStart: '<!--SNIPSTART',
-  writeStartClose: '-->',
-  writeEnd: '<!--SNIPEND',
+  writeMarkerStyles: [
+    { openStart: '<!--SNIPSTART', openClose: '-->', end: '<!--SNIPEND' },     // HTML comment
+    { openStart: '{/* SNIPSTART', openClose: '*/}', end: '{/* SNIPEND' },     // MDX/JSX comment
+  ],
 };

--- a/test/fixtures/jsx-marker.mdx
+++ b/test/fixtures/jsx-marker.mdx
@@ -1,0 +1,6 @@
+Text above snippet
+
+{/*SNIPSTART typescript-hello-activity*/}
+{/*SNIPEND*/}
+
+Text below snippet

--- a/test/fixtures/mixed-markers.mdx
+++ b/test/fixtures/mixed-markers.mdx
@@ -1,0 +1,9 @@
+Test before snippet
+
+{/* SNIPSTART a */}
+<!--SNIPEND-->
+<!--SNIPSTART b -->
+{/* SNIPEND */}
+
+
+Text after snippet


### PR DESCRIPTION
This PR:
- Adds matching for MDX style comments. Also added guardrails for mixing the two style of tags.
- Increments the package version so we can publish it on npm later
- Adds a `.gitattribute` file to avoid line ending issues, which both Milecia and I ran into earlier. 